### PR TITLE
chore: Update referenced nuget packages

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,12 +16,12 @@ jobs:
     name: Build
     runs-on: ${{ matrix.os }}
     env:
-      version: '2.1.0'
-      versionFile: '2.1.0'
+      version: '2.2.0'
+      versionFile: '2.2.0'
       packDotNetVersion: '8'
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
         dotnet-version: [ '3.x', '6.x', '8.x' ]
 
     steps:

--- a/Src/Axuno.VirtualFileSystem.Tests/Axuno.VirtualFileSystem.Tests.csproj
+++ b/Src/Axuno.VirtualFileSystem.Tests/Axuno.VirtualFileSystem.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Axuno.VirtualFileSystem\Axuno.VirtualFileSystem.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -16,12 +16,13 @@
     <EmbeddedResource Include="Assets\Text\Testfile_{2}.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NUnit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" Condition="'$(TargetFramework)'=='net8.0'" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)'!='net8.0'"/>
+    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/Axuno.VirtualFileSystem/Axuno.VirtualFileSystem.csproj
+++ b/Src/Axuno.VirtualFileSystem/Axuno.VirtualFileSystem.csproj
@@ -39,10 +39,10 @@ The library is a modified version of Volo.Abp.VirtualFileSystem 7.0</Description
       <IncludeSymbols>true</IncludeSymbols>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.6" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Src/Directory.Build.props
+++ b/Src/Directory.Build.props
@@ -1,9 +1,8 @@
 <Project>
-
     <PropertyGroup>
         <Product>Axuno.VirtualFileSystem</Product>
-        <Version>2.1.0</Version>
-        <FileVersion>2.1.0</FileVersion>
+        <Version>2.2.0</Version>
+        <FileVersion>2.2.0</FileVersion>
         <AssemblyVersion>2.0.0.0</AssemblyVersion> <!--only update AssemblyVersion with major releases -->
         <Company>axuno gGmbH</Company>
         <Authors>axuno gGmbH</Authors>
@@ -16,5 +15,4 @@
         <AnalysisLevel>latest</AnalysisLevel>
         <Features>strict</Features>
     </PropertyGroup>
-
 </Project>


### PR DESCRIPTION
**Main**
Microsoft.Extensions.FileProviders.Composite v8.0.0 -> v9.0.6 Microsoft.Extensions.FileProviders.Embeddedv v8.0.6 -> 9.0.6 Microsoft.Extensions.FileProviders.Physical v8.0.0 -> 9.0.6 Microsoft.Extensions.Options v8.0.2 -> 9.0.6

**Tests**
Update test project to `net8.0`
Microsoft.Extensions.DependencyInjection v8.0.0 -> v9.0.6 Microsoft.Extensions.Logging.Abstractions v8.0.0 -> v9.0.6 Microsoft.NET.Test.Sdk v17.13.0 -> v17.14.1
NUnit v4.3.0 -> v4.3.2
NUnit3TestAdapter v4.2.1 -> v5.0.0
NUnit.Analyzers v4.8.0 -> v4.9.2

Bump version to v2.2.0

**CI Build**
Update `dotnet.yml` to use `ubuntu-22.04` instead of `ubuntu-latest` because of missing libssl failure with `ubuntu-24.04`