### PR TITLE
Supported TFM are now `netstandard2.1` and `net8.0`, dropped `net6.0`

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        dotnet-version: [ '3.x', '6.x', '8.x' ]
+        dotnet-version: [ '3.x', '8.x' ]
 
     steps:
     - name: Checkout

--- a/Src/Axuno.VirtualFileSystem.Tests/Axuno.VirtualFileSystem.Tests.csproj
+++ b/Src/Axuno.VirtualFileSystem.Tests/Axuno.VirtualFileSystem.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Axuno.VirtualFileSystem\Axuno.VirtualFileSystem.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
@@ -16,13 +16,13 @@
     <EmbeddedResource Include="Assets\Text\Testfile_{2}.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" Condition="'$(TargetFramework)'=='net8.0'" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)'!='net8.0'"/>
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.9.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" Condition="'$(TargetFramework)'!='net8.0'" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Src/Axuno.VirtualFileSystem/Axuno.VirtualFileSystem.csproj
+++ b/Src/Axuno.VirtualFileSystem/Axuno.VirtualFileSystem.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <NoWarn>$(NoWarn);1591</NoWarn>
         <SignAssembly>true</SignAssembly>
@@ -39,10 +39,10 @@ The library is a modified version of Volo.Abp.VirtualFileSystem 7.0</Description
       <IncludeSymbols>true</IncludeSymbols>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="9.0.6" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.6" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.6" />
-        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="9.0.9" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.9" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.9" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
chore: Update referenced nuget packages